### PR TITLE
Add express checkout form, with redirect hook for job checkout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# TMGMT Express Checkout
+
+Reduce amount of clicking when creating multiple translation jobs.
+
+This adds an express checkout form that is automatically presented when 2 or more translation jobs need to be checked out. The form allows a single name and translator selection to be used for a set of jobs that translate the same documents into different languages.
+
+The form can be skipped to proceed to the standard form-per-job checkout.
+
+
+## Requirements
+
+This module requires TMGMT module to be installed.
+
+
+## Installation
+
+Place the module directory in your usual Drupal modules directory.
+
+Activate the module through the Drupal administration interface, or whichever
+way you prefer to activate modules.
+
+
+## Setup
+
+After installing and activating the module, it should work with no additional
+setup.
+
+
+## Usage
+
+Use TMGMT to create multiple translation jobs. For example add items to the
+cart, open the cart and select multiple languages, then click "Request
+translation".
+
+The express checkout form will be shown automatically whenever multiple job
+checkout forms would be shown.
+
+To checkout all the jobs at once:
+
+ - Enter a name to use for all the created jobs.
+ - Select the translator plugin to use for all the created jobs.
+ - Click "Request translation".
+
+To skip express checkout and use the default checkout forms, click "Cancel
+(resume normal checkout)".

--- a/tmgmt_express_checkout.module
+++ b/tmgmt_express_checkout.module
@@ -37,11 +37,6 @@ function tmgmt_express_checkout_menu() {
  */
 function tmgmt_express_checkout_tmgmt_ui_job_checkout_before_alter(&$redirects, &$jobs) {
 
-  // TODO maybe remove this check, to keep it consistent
-  if (sizeof($jobs) < 2) {
-    return;
-  }
-
   // Array of [name => label]
   $translators = tmgmt_translator_labels();
 

--- a/tmgmt_express_checkout.module
+++ b/tmgmt_express_checkout.module
@@ -192,7 +192,7 @@ function tmgmt_express_checkout_express_checkout_form_submit($form, &$form_state
   // clear the tmgmt redirect queue since all jobs in the queue are processed.
   tmgmt_ui_redirect_queue_set(array());
 
-  $form_state['redirect'] = 'admin/tmgmt/jobs';
+  $form_state['redirect'] = 'admin/tmgmt';
 }
 
 /**

--- a/tmgmt_express_checkout.module
+++ b/tmgmt_express_checkout.module
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * Main module file.
+ *
+ * This is where all the hooks go that Drupal will use directly to get info.
+ *
+ * The module is activated in the .info file.
+ */
+
+
+/**
+ * Implements hook_menu()
+ */
+function tmgmt_express_checkout_menu() {
+  $items = array();
+
+  $items['admin/tmgmt/express_checkout'] = array(
+    'title' => 'Express checkout title',
+    'description' => 'Express checkout description',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('tmgmt_express_checkout_express_checkout_form'),
+    'access callback' => TRUE,
+    // this prevents the form displaying in the main navigation menu
+    'menu_name' => 'tmgmt_express_checkout',
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_tmgmt_ui_job_checkout_before_alter()
+ *
+ * Called when jobs have been created, but before all the individual checkout
+ * forms. Jobs and redirects can be modified here to change the checkout
+ * workflow.
+ */
+function tmgmt_express_checkout_tmgmt_ui_job_checkout_before_alter(&$redirects, &$jobs) {
+
+  // TODO maybe remove this check, to keep it consistent
+  if (sizeof($jobs) < 2) {
+    return;
+  }
+
+  // Array of [name => label]
+  $translators = tmgmt_translator_labels();
+
+  // reset pointer to first element
+  reset($translators);
+  // get key at pointer
+  $default_translator = key($translators);
+
+  // save the job ids in the session, for use by the express checkout form
+  $job_ids = array();
+  foreach ($jobs as $job) {
+    $job_ids[] = $job->tjid;
+  }
+  if (!isset($_SESSION['tmgmt_express_checkout'])) {
+    $_SESSION['tmgmt_express_checkout'] = array();
+  }
+  $_SESSION['tmgmt_express_checkout']['job_ids'] = $job_ids;
+
+  $redirects[] = 'admin/tmgmt/express_checkout';
+}
+
+/**
+ * Express checkout form, used when there are 2 or more jobs to check out.
+ */
+function tmgmt_express_checkout_express_checkout_form($form, &$form_state) {
+
+  $job_ids = array();
+
+  if (isset($_SESSION['tmgmt_express_checkout'])) {
+    $cache = $_SESSION['tmgmt_express_checkout'];
+    if (isset($cache['job_ids'])) {
+      $job_ids = $cache['job_ids'];
+    }
+  }
+
+  $form['job_ids'] = array(
+    // value type is not sent to client, but is available in submit function
+    '#type' => 'value',
+    '#value' => $job_ids,
+  );
+
+  $form['description'] = array(
+    '#markup' => t('Express checkout can configure and submit all new translation jobs at once (%job_count jobs).',
+    array(
+      '%job_count' => count($job_ids),
+    )),
+  );
+
+  // Use the first job to generate a default job label.
+  if (count($job_ids) >= 1) {
+    $first_job_id = reset($job_ids);
+    $first_job = tmgmt_job_load($first_job_id);
+    $default_job_name = $first_job->defaultLabel();
+    // TODO consider whether to use ->label() instead
+  }
+  else {
+    $default_job_name = 'Translation job';
+  }
+
+  $form['job_name_prefix'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Job name'),
+    '#description' => t('The default name to use for the created translation jobs.'),
+    '#default_value' => $default_job_name,
+    '#required' => TRUE,
+  );
+
+  $translators = tmgmt_translator_labels();
+  // reset returns first element, or FALSE
+  $default_translator = reset($translators);
+
+  $form['translator_wrapper'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Translator selection'),
+  );
+
+  $form['translator_wrapper']['translator'] = array(
+    '#type' => 'select',
+    '#title' => t('Translator'),
+    '#description' => t('The configured translator plugin that will process of the translation.'),
+    '#options' => $translators,
+    '#default_value' => $default_translator,
+    '#required' => TRUE,
+  );
+
+  $form['translator_wrapper']['settings'] = array(
+    '#markup' => t('Express checkout does not allow custom translator settings.'),
+  );
+
+  // TODO only allow submit if 1 or more languages are selected
+
+  $form['actions'] = array(
+    '#type' => 'fieldset',
+  );
+
+  $form['actions']['request_translation_express'] = array(
+    '#type' => 'submit',
+    '#value' => t('Request translation'),
+    // '#submit' => array('tmgmt_ui_cart_request_translation_form_submit'),
+    '#submit' => array('tmgmt_express_checkout_express_checkout_form_submit'),
+    '#validate' => array('tmgmt_express_checkout_express_checkout_form_validate'),
+  );
+
+  $form['actions']['cancel'] = array(
+    '#type' => 'submit',
+    '#value' => t('Cancel (resume normal checkout)'),
+    // '#submit' => array('tmgmt_ui_cart_request_translation_form_submit'),
+    '#submit' => array('tmgmt_express_checkout_express_checkout_form_cancel'),
+    // '#validate' => array('tmgmt_express_checkout_express_checkout_form_validate'),
+  );
+
+  return $form;
+}
+
+function tmgmt_express_checkout_express_checkout_form_validate($form, &$form_state) {
+}
+
+/**
+ * Submit handler for express checkout form.
+ */
+function tmgmt_express_checkout_express_checkout_form_submit($form, &$form_state) {
+  // TODO check if 'values' is right, there may be a different field for the
+  //      submitted values when the form is complete.
+
+  $default_label = $form_state['values']['job_name_prefix'];
+  $translator = $form_state['values']['translator'];
+  $job_ids = $form_state['values']['job_ids'];
+
+  $jobs = array();
+  foreach ($job_ids as $job_id) {
+    $job = tmgmt_job_load($job_id);
+
+    // TODO append language name to label ($job->target_language)
+    // TODO show example language name where the label is entered
+    $job->label = $default_label;
+    $job->translator = $translator;
+    $job->requestTranslation();
+
+    $job->save();
+  }
+
+  drupal_set_message(t('Checked out %job_count translation jobs.', array(
+    '%job_count' => count($job_ids),
+  )));
+
+
+  // clear the cached job_ids now that they have been processed.
+  if (!isset($_SESSION['tmgmt_express_checkout'])) {
+    $_SESSION['tmgmt_express_checkout'] = array();
+  }
+  unset($_SESSION['tmgmt_express_checkout']['job_ids']);
+
+  // clear the tmgmt redirect queue since all jobs in the queue are processed.
+  tmgmt_ui_redirect_queue_set(array());
+
+  $form_state['redirect'] = 'admin/tmgmt/jobs';
+}
+
+/**
+ * Cancel handler for express checkout form (resume normal checkout instead).
+ */
+function tmgmt_express_checkout_express_checkout_form_cancel($form, &$form_state) {
+  // clear the cached job_ids now that they will not be used.
+  if (!isset($_SESSION['tmgmt_express_checkout'])) {
+    $_SESSION['tmgmt_express_checkout'] = array();
+  }
+  unset($_SESSION['tmgmt_express_checkout']['job_ids']);
+
+  // redirect to default tmgmt job checkout queue
+  $form_state['redirect'] = tmgmt_ui_redirect_queue_dequeue();
+}


### PR DESCRIPTION
This PR is just created as a place to keep track of reviewing and testing of the initial implementation.

https://bugzilla.redhat.com/show_bug.cgi?id=1227579

https://www.drupal.org/project/tmgmt_express_checkout
## Testing notes

Requirements: assumes module TMGMT is installed.
### Setup:
1. Clone this repository in the Drupal module folder (mine is at `/var/www/html/quick-drupal/sample-drupal/drupal/sites/all/modules/`).
2. `git checkout 7.x-1.x`
3. In the drupal directory, run `drush pm-enable tmgmt_express_checkout -y` to enable the module. (my drupal directory is `/var/www/html/quick-drupal/sample-drupal/drupal`).

To update with new code, the module should be disabled while the new code is added:

```
# from drupal directory
drush pm-disable tmgmt_express_checkout
cd sites/all/modules/tmgmt_express_checkout
git pull 7.x-1.x
cd ../../../..
drush pm-enable tmgmt_express_checkout
```
### Testing:

The new form is shown when multiple translation jobs are created at once. To create multiple translation jobs at once:
1. Add items to translation cart
   - Open translation sources (Admin menu Translation -> Sources, opens `/admin/tmgmt/sources`)
   - Select documents (use checkboxes to left of documents)
   - Click 'Add to cart'
2. Open translation cart (Admin menu Translation -> Cart, opens `/admin/tmgmt/cart`)
3. Select all documents in the table
4. Select multiple languages that are not the source language (hold Ctrl to select multiple)
5. Click 'Request translations'

Expected: show a form where user can enter a name and select a translator (the 'express checkout' form).

There are 2 possible paths from the express checkout form:
- Request translations: creates all the translation jobs, then redirects to the translation jobs page `/admin/tmgmt/jobs` (aliased to `/admin/tmgmt`), with a message indicating the number of jobs that were checked out.
- Cancel: shows each of the individual checkout forms (which is the default behaviour of TMGMT without this module installed).
### Known Issues
- TMGMT generates a message saying that there are N+1 jobs to check out, where N is the actual number of translation jobs that need to be checked out. This is submitted as a bug on TMGMT: https://www.drupal.org/node/2509748
